### PR TITLE
Added Docker files for Node 11 and 12

### DIFF
--- a/11.15.0/Dockerfile
+++ b/11.15.0/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:11.15.0
+
+RUN npm install -g gulp webpack
+
+VOLUME [ '/app' ]
+WORKDIR /app

--- a/12.5.0/Dockerfile
+++ b/12.5.0/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:12.5.0
+
+RUN npm install -g gulp webpack
+
+VOLUME [ '/app' ]
+WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Supported tags and respective `Dockerfile` links
+ - `12.5.0` `latest` (*[12.5.0/Dockerfile](https://github.com/thedrum-developers/docker-frontend-build/blob/master/12.5.0/Dockerfile)*)
+ - `11.15.0` `latest` (*[12.5.0/Dockerfile](https://github.com/thedrum-developers/docker-frontend-build/blob/master/11.15.0/Dockerfile)*)
  - `0.2`, `latest` (*[0.2/Dockerfile](https://github.com/thedrum-developers/docker-frontend-build/blob/master/0.2/Dockerfile)*)
  - `0.1` (*[0.1/Dockerfile](https://github.com/thedrum-developers/docker-frontend-build/blob/master/0.1/Dockerfile)*)
+
+_* Changed the naming convention to reflect the version of Node that corresponds to the build._
+
+_* Use Node 11 to rebuild node-gyp if required as it currently won't build with Node 12._
+


### PR DESCRIPTION
Added docker files for Node 11 and Node 12. If you need to rebuild node-gyp then you will have to build with Node 11 as Node 12 can't build it as yet. Changed versioning to reflect the node version.